### PR TITLE
修复一些问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,169 @@
+﻿# Byte-compiled / optimized / DLL files
+__pycache__/
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Visual Studio
+.vs/
+*.pyproj
+*.sln
+
+# Github Release
+release/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/ManagementServer/api.py
+++ b/ManagementServer/api.py
@@ -25,7 +25,7 @@ async def get_client_manifest(uid: str=None, version: int=int(time.time())):
         profile_config = Datas.ProfileConfig.profile_config
         _return =  {
             "ClassPlanSource": {
-                "Value": f"http://127.0.0.1:50050/api/v1/client/classPlan?name={profile_config[uid]["ClassPlan"]}", # 使用 client_profile 中的配置，默认为 default
+                "Value": f"http://127.0.0.1:50050/api/v1/client/classPlan?name={profile_config[uid]['ClassPlan']}", # 使用 client_profile 中的配置，默认为 default
                 "Version": version
             },
             "TimeLayoutSource": {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 运行 `python -m grpc_tools.protoc --proto_path=. --python_out=. --grpc_python_out=. .\Protobuf\Client\*.proto .\Protobuf\Command\*.proto .\Protobuf\Enum\*.proto .\Protobuf\Server\*.proto .\Protobuf\Service\*.proto` 以编译 `.proto` 文件
 
-运行 `pythom -m pip install -r requirements.txt` 以安装依赖
+运行 `python -m pip install -r requirements.txt` 以安装依赖
 
 现在，你可以直接启动 [`main.py`](./main.py)，也可以到到 [`Notebook`](./ServerPresentation.ipynb) 阅读一些其它的相关信息。
 


### PR DESCRIPTION
1. 修复 README 中安装依赖项命令错误：
pythom -m pip install -r requirements.txt 应为
python -m pip install -r requirements.txt

2. 修复 ManagementServer/api.py 中引号错误：
第28行 "Value": f"http://127.0.0.1:50050/api/v1/client/classPlan?name={profile_config[uid]["ClassPlan"]}", 应为
"Value": f"http://127.0.0.1:50050/api/v1/client/classPlan?name={profile_config[uid]['ClassPlan']}",

3. 增加 .gitignore：
忽略构建生成的文件，仅保留源代码
